### PR TITLE
add build essential when running vagrant

### DIFF
--- a/cfp/Makefile
+++ b/cfp/Makefile
@@ -61,14 +61,14 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: run-api
-run-api: ## Run the cfp api server
+run-api: clean-api ## Run the cfp api server
 	cd ../cfp-api && go mod tidy \
 	&& go run main.go &
 
 .PHONY: clean-api
 clean-api: ## clean cfp api server
-	@- kill -9 $$(lsof -t -i $(CFP_API_PORT))
-	rm -Rf ../cfp-api/data
+	@- kill -9 $$(lsof -t -i $(CFP_API_PORT)) || true
+	rm -Rf ../cfp-api/data || true
 
 .PHONY: test
 test: manifests generate fmt vet envtest run-api ## Run tests.

--- a/cfp/config/crd/bases/talks.kubecon.na_proposals.yaml
+++ b/cfp/config/crd/bases/talks.kubecon.na_proposals.yaml
@@ -79,7 +79,7 @@ spec:
           status:
             description: ProposalStatus defines the observed state of Proposal
             properties:
-              conditions:omitempty:
+              conditions:
                 description: Conditions is a list of conditions and their status.
                 items:
                   description: "Condition contains details for one aspect of the current
@@ -148,7 +148,7 @@ spec:
                   - type
                   type: object
                 type: array
-              lastUpdate:omitempty:
+              lastUpdate:
                 description: The time at which the proposal was submitted
                 format: date-time
                 type: string
@@ -157,7 +157,7 @@ spec:
                   the Speaker object.
                 format: int64
                 type: integer
-              submission:omitempty:
+              submission:
                 description: Submission represents the current status of the proposal
                   It can be draft or final
                 enum:

--- a/dev/vagrant/Vagrantfile
+++ b/dev/vagrant/Vagrantfile
@@ -82,6 +82,7 @@ Vagrant.configure("2") do |config|
       #!/usr/bin/env bash
       set -eux -o pipefail
       apt install -y \
+        build-essential \
         make \
         git \
         ca-certificates \


### PR DESCRIPTION
This is needed because `cgo` needs `gcc`.